### PR TITLE
[Website] Add AccessLint CI to run accessibility tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 5.1.0
+  environment:
+    ACCESSLINT_MASTER_BRANCH: "staging"
 
 test:
   pre:
@@ -10,3 +12,7 @@ test:
     - npm run build:package # Run the release process
   post:
     - ls -agolf dist/ # Ensure that build:package worked
+    - ls -agolf _site/ # Ensure that build:website worked
+    - |
+      bundle exec jekyll serve --detach --no-watch && \
+      accesslint-ci scan http://localhost:4000

--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,30 @@
+general:
+  artifacts:
+    - "tmp"
+
 machine:
-  node:
-    version: 5.1.0
   environment:
     ACCESSLINT_MASTER_BRANCH: "staging"
+  node:
+    version: 5.1.0
+  ruby:
+    version: 2.3.1
+
+dependencies:
+  post:
+    - gem install jekyll
+    - gem install accesslint-ci
+    - npm install -g accesslint-cli
 
 test:
   pre:
     - gulp -v
+    - jekyll -v
   override:
     - npm test # Run the package and docs test suite
     - npm run build:package # Run the release process
   post:
     - ls -agolf dist/ # Ensure that build:package worked
-    - ls -agolf _site/ # Ensure that build:website worked
     - |
-      bundle exec jekyll serve --detach --no-watch && \
+      jekyll serve --detach --no-watch && \
       accesslint-ci scan http://localhost:4000


### PR DESCRIPTION
## Overview

- Runs [accesslint-ci][blog] on the entire site for new pull requests and comments on the PR with accessibility issues.
- CI will *not* fail on accessibility errors. accesslint-ci will comment on the pull requests.
- The first PR with this change will list all of the accessibility issues on the site.
- Subsequent PRs will only receive comments there are new changes.

[blog]: https://robots.thoughtbot.com/introducing-accesslint-web-accessibility-testing-in-ci

### Example scenario

- Developer branches from the development branch (`staging`).
- Developer makes changes that introduce accessibility issues (form element with a missing label).
- Developer opens a pull request in GitHub with the changes.
- Developer gets a comment notification that his or her PR introduced 1 new error, including the url, criticality, and CSS selector of the failing element, like so:

```
'http://localhost:4000/form-templates/ | serious | Form elements must have labels | ["#\\30 3-sign-in-form > .preview > .usa-form > fieldset > input:nth-of-type(2)", "#\\30 4-password-reset-form > .preview > .usa-form > fieldset > .js-validate_password"]'
```

## Technical details

- Installs [`accesslint-cli`][cli].
  - `accesslint-cli` is a node module that injects the [axe-core][axe] library into a page to run accessibility tests.
- Installs [`accesslint-ci`][ci].
  - crawls a host and passes the urls to `accesslint-cli` for accessibility evaluation.
- Set `ACCESSLINT_MASTER_BRANCH`.
  - AccessLint CI stores accessibility logs in Circle CI artifacts
    for every build. It compares logs for new builds against the last
    successful build on the mainline branch (default `master`). This
    setting specifies `staging` as the branch with which to compare new
    results.
- Run a detached jekyll server for crawling and analysis.
- Scan the host served via jekyll with `accesslint-ci`

[cli]: https://github.com/accesslint/accesslint-cli.js
[axe]: https://github.com/dequelabs/axe-core
[ci]: https://github.com/accesslint/accesslint-ci

## Circle CI setup

- Set the following in [Circle CI environment variables][circle-env]
  - `ACCESSLINT_GITHUB_TOKEN` - [GitHub personal access token][github]
    from a [collaborator account with write permissions][collaborator]
  - `CIRCLE_TOKEN` - [Circle CI API token][circle-api]

[circle-env]: https://circleci.com/gh/18F/web-design-standards/edit#env-vars
[github]: https://github.com/settings/tokens/new
[collaborator]: https://github.com/18F/web-design-standards/settings/collaboration
[circle-api]: https://circleci.com/account/api